### PR TITLE
added missing option "quietly" for fit_OU

### DIFF
--- a/R/shift_configuration.R
+++ b/R/shift_configuration.R
@@ -742,6 +742,7 @@ fit_OU <- function(tree, Y, shift.configuration,
     }else{
         opt$criterion            <- match.arg(criterion)
         opt$root.model           <- match.arg(root.model)
+        opt$quietly              <- TRUE
         opt$alpha.starting.value <- alpha.starting.value
         opt$alpha.upper.bound    <- alpha.upper
         opt$alpha.lower.bound    <- alpha.lower


### PR DESCRIPTION
This is to fix an error, which can be reproduced on this example:

```r
library(l1ou)
library(geiger)
set.seed(120)
ntaxa = 10
tr = rcoal(ntaxa)
x = c(rnorm(5, 15, 1), rnorm(5, 15, 1)) # no shift: so shift.configuration=NULL below
names(x) = tr$tip.label
ll = adjust_data(tr, x, normalize=FALSE)
myzero = 0.0 # same error with 1e-16 or smaller.
# force alpha=0 below, which does not fit the data, hence numerical instability
fo = fit_OU(ll$tree, ll$Y, shift.configuration=NULL, criterion="pBIC",
            alpha.starting.value=myzero, alpha.upper=myzero, alpha.lower=myzero)
```

It returns this error with this traceback:

    Error in !silent : invalid argument type
    8. value[[3L]](cond)
    7. tryCatchOne(expr, names, parentenv, handlers[[1L]])
    6. tryCatchList(expr, classes, parentenv, handlers)
    5. tryCatch(expr, error = function(e) { call <- conditionCall(e) if (!is.null(call)) { if (identical(call[[1L]], quote(doTryCatch))) ...
    4. try(phylolm(Y ~ preds - 1, phy = tree, model = opt$root.model, starting.value = s, lower.bound = l, upper.bound = u), silent = opt$quietly)
    3. my_phylolm_interface(tr, y, s.c, opt)
    2. fit_OU_model(tree, Y, shift.configuration, opt)
    1. fit_OU(ll$tree, ll$Y, shift.configuration = NULL, criterion = "pBIC", alpha.starting.value = myzero, alpha.upper = myzero, alpha.lower = myzero)
