### PR TITLE
Updated is.binary.tree to is.binary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ NeedsCompilation: yes
 Depends:
     R (>= 3.1.0),
     igraph,
-    ape,
+    ape (>= 4.0),
     phylolm (>= 2.0.0),
     lars,
     parallel,

--- a/R/sqrt_OU_covariance.R
+++ b/R/sqrt_OU_covariance.R
@@ -65,7 +65,7 @@
 #'@export
 sqrt_OU_covariance <- function(tree, alpha=0, root.model = c("OUfixedRoot", "OUrandomRoot"), 
                                check.order=TRUE, check.ultrametric=TRUE){
-    if( ! is.binary.tree(tree) ){
+    if( ! is.binary(tree) ){
         tree         <- multi2di(tree, random=FALSE)
         check.order  <- TRUE 
     }


### PR DESCRIPTION
Running estimate_shift_configuration() threw warnings due to ape deprecating is.binary.tree() in favor of is.binary()

The warning from the ape package:

> is.binary.tree() is deprecated; using is.binary() instead.
> 
> is.binary.tree() will be removed soon: see ?is.binary and update your code.